### PR TITLE
Add gz-jetty-fuel-tools alias packages

### DIFF
--- a/ubuntu/debian/control
+++ b/ubuntu/debian/control
@@ -56,3 +56,11 @@ Description: Gazebo fuel-tools classes and functions - Development files
  manage different 3D robotics models.
  .
  The package ships the Gazebo fuel development headers and libraries
+
+Package: gz-jetty-fuel-tools
+Depends: libgz-fuel-tools11-dev (= ${binary:Version}), ${misc:Depends}
+Architecture: all
+Priority: optional
+Section: metapackages
+Description: alias package
+ Provides a package for Jetty without exposing the version number.


### PR DESCRIPTION
Add gz-jetty-fuel-tools* packages that depend on the corresponding libgz-fuel-tools11* packages.

Part of https://github.com/gazebo-tooling/release-tools/issues/1326.